### PR TITLE
Use MANAGE_AUTHENTICATION_SETTINGS permission in SamlSettingsAdminPag…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <teamcity-version-lib>2020.1</teamcity-version-lib>
+        <teamcity-version-lib>2020.1.1</teamcity-version-lib>
         <teamcity-version-runtime>2020.1.2</teamcity-version-runtime>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <teamcity-version-lib>2020.1.1</teamcity-version-lib>
+        <teamcity-version-lib>2020.1</teamcity-version-lib>
         <teamcity-version-runtime>2020.1.2</teamcity-version-runtime>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/saml-authentication-server/src/main/java/jetbrains/buildServer/auth/saml/plugin/SamlSettingsAdminPage.java
+++ b/saml-authentication-server/src/main/java/jetbrains/buildServer/auth/saml/plugin/SamlSettingsAdminPage.java
@@ -62,7 +62,15 @@ public class SamlSettingsAdminPage extends AdminPage {
     @Override
     public boolean isAvailable(@NotNull HttpServletRequest request) {
         return super.isAvailable(request)
-                && checkHasGlobalPermission(request, Permission.MANAGE_AUTHENTICATION_SETTINGS)
+                && checkHasGlobalPermission(request, getRequiredPermission())
                 && samlAuthenticationScheme.isConfigured();
+    }
+
+    private Permission getRequiredPermission() {
+        if (Permission.lookupPermission("MANAGE_AUTHENTICATION_SETTINGS") != null) {
+            //this permission was introduced in TeamCity 2020.1.1, so it may not exist when the server is older than 2020.1.1
+            return Permission.lookupPermission("MANAGE_AUTHENTICATION_SETTINGS");
+        }
+        return Permission.CHANGE_SERVER_SETTINGS;
     }
 }

--- a/saml-authentication-server/src/main/java/jetbrains/buildServer/auth/saml/plugin/SamlSettingsAdminPage.java
+++ b/saml-authentication-server/src/main/java/jetbrains/buildServer/auth/saml/plugin/SamlSettingsAdminPage.java
@@ -62,7 +62,7 @@ public class SamlSettingsAdminPage extends AdminPage {
     @Override
     public boolean isAvailable(@NotNull HttpServletRequest request) {
         return super.isAvailable(request)
-                && checkHasGlobalPermission(request, Permission.CHANGE_SERVER_SETTINGS)
+                && checkHasGlobalPermission(request, Permission.MANAGE_AUTHENTICATION_SETTINGS)
                 && samlAuthenticationScheme.isConfigured();
     }
 }


### PR DESCRIPTION
In TeamCity 2020.1.1 a new permission was introduced: MANAGE_AUTHENTICATION_SETTINGS, it makes sense to use instead of CHANGE_SERVER_SETTINGS

This will allow the plugin to be used in TeamCity Cloud where all users don't have CHANGE_SERVER_SETTINGS permission