### PR TITLE
bump commons validator for CVE in beansutils CVE-2019-10086

### DIFF
--- a/saml-authentication-server/pom.xml
+++ b/saml-authentication-server/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <exclusions>
                 <exclusion>
                     <groupId>xml-apis</groupId>


### PR DESCRIPTION
Bump commons-validator to 1.7 which bumps its dependency for commons-beanutils to 1.9.4