### PR TITLE
Update debug log config format to log4j 2

### DIFF
--- a/docs/debug-auth-saml.xml
+++ b/docs/debug-auth-saml.xml
@@ -1,429 +1,416 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE log4j:configuration SYSTEM "./log4j.dtd">
-
-<!--
-The file can be modified without application restart, but some changes can still require restart to take effect.
-
-You might also need to increase the number of files to store to prevent logs from quick rotation
-   <param name="maxBackupIndex" value="20"/>
--->
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
-  <appender name="CONSOLE-WARN" class="org.apache.log4j.ConsoleAppender">
-    <param name="target" value="System.err" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p [%30.30t] - %30.30c - %m%n" />
-    </layout>
-    <filter class="jetbrains.buildServer.util.SpringErrorsFilter">
-      <param name="LevelMin" value="WARN" />
-    </filter>
-  </appender>
-  <appender name="CONSOLE-ERROR" class="org.apache.log4j.ConsoleAppender">
-    <param name="target" value="System.err" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p [%30.30t] - %30.30c - %m%n" />
-    </layout>
-    <filter class="jetbrains.buildServer.util.SpringErrorsFilter">
-      <param name="LevelMin" value="ERROR" />
-    </filter>
-  </appender>
-  <appender name="ROLL" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-server.log" />
-    <param name="maxBackupIndex" value="10" />
-    <!--REPLACE PREVIOUS LINE WITH UNCOMMENTED LINE TO STORE MORE LOGS-->
-    <!-- <param name="maxBackupIndex" value="20"/> -->
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m%n" />
-    </layout>
-    <filter class="jetbrains.buildServer.log.CategoryFilter">
-      <param name="DenyCategory" value="javasvn.output" />
-    </filter>
-    <filter class="jetbrains.buildServer.log.CategoryFilter">
-      <param name="DenyCategory" value="jetbrains.buildServer.plugins.spring.SpringPluginLoader$TeamCityPlugin*" />
-      <param name="MaxDenyLevel" value="INFO" />
-    </filter>
-    <filter class="jetbrains.buildServer.log.CategoryFilter">
-      <param name="DenyCategory" value="jetbrains.buildServer.vcs.impl.VcsContentCache" />
-      <param name="MaxDenyLevel" value="INFO" />
-    </filter>
-    <filter class="jetbrains.buildServer.log.CategoryFilter">
-      <param name="DenyCategory" value="jetbrains.buildServer.LDAP" />
-      <param name="MaxDenyLevel" value="DEBUG" />
-    </filter>
-    <filter class="jetbrains.buildServer.log.CategoryFilter">
-      <param name="DenyCategory" value="jetbrains.buildServer.maintenance.WebDispatcherServlet" />
-      <param name="MaxDenyLevel" value="INFO" />
-    </filter>
-    <filter class="jetbrains.buildServer.log.CategoryFilter">
-      <param name="DenyCategory" value="jetbrains.buildServer.CLEANUP" />
-      <param name="MaxDenyLevel" value="DEBUG" />
-    </filter>
-    <filter class="jetbrains.buildServer.log.CategoryFilter">
-      <param name="DenyCategory" value="jetbrains.buildServer.AUTH*" />
-      <param name="MaxDenyLevel" value="INFO" />
-    </filter>
-    <filter class="jetbrains.buildServer.log.CategoryFilter">
-      <param name="DenyCategory" value="jetbrains.buildServer.nuget.*" />
-      <param name="MaxDenyLevel" value="INFO" />
-    </filter>
-    <filter class="jetbrains.buildServer.log.CategoryFilter">
-      <param name="DenyCategory" value="jetbrains.buildServer.web.ResponseFragmentFilter*" />
-      <param name="MaxDenyLevel" value="DEBUG" />
-    </filter>
-  </appender>
-  <appender name="ROLL.NODES" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-nodes.log" />
-    <param name="maxBackupIndex" value="3" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m %n" />
-    </layout>
-  </appender>
-  <appender name="ROLL.VCS" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-vcs.log" />
-    <param name="maxBackupIndex" value="3" />
-    <!--REPLACE PREVIOUS LINE WITH UNCOMMENTED LINE TO STORE MORE LOGS-->
-    <!-- <param name="maxBackupIndex" value="20"/> -->
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p [%15.15t] - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="ROLL.VCS_STATES" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-vcs-states.log" />
-    <param name="maxBackupIndex" value="3" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p [%15.15t] - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="ROLL.VCS.REMOTE.RUN" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-remote-run.log" />
-    <param name="maxBackupIndex" value="5" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p [%15.15t] - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="ROLL.WS" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-ws.log" />
-    <param name="maxBackupIndex" value="3" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p [%15.15t] - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="ACTIVITIES.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-activities.log" />
-    <param name="maxBackupIndex" value="1" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="CLOUDS.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-clouds.log" />
-    <param name="maxBackupIndex" value="10" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p [%15.15t] - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="SQL.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-sql.log" />
-    <param name="maxBackupIndex" value="3" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30t - %m%n" />
-    </layout>
-  </appender>
-  <appender name="CLEANUP.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-cleanup.log" />
-    <param name="maxBackupIndex" value="3" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="SVN.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-svn.log" />
-    <param name="maxBackupIndex" value="10" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="TFS.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-tfs.log" />
-    <param name="maxBackupIndex" value="1" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="STARTEAM.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-starteam.log" />
-    <param name="maxBackupIndex" value="1" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p [%t] - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="CLEARCASE.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-clearcase.log" />
-    <param name="maxBackupIndex" value="1" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p [%t] - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="AUTH.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-auth.log" />
-    <param name="maxBackupIndex" value="10" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p [%30.30t] - %m%n" />
-    </layout>
-  </appender>
-  <appender name="AGENT_STATISTICS.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-agent-statistics.log" />
-    <param name="maxBackupIndex" value="1" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="%m%n" />
-    </layout>
-  </appender>
-  <appender name="XMLRPC.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-xmlrpc.log" />
-    <param name="maxBackupIndex" value="1" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="LDAP.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-ldap.log" />
-    <param name="maxBackupIndex" value="1" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="VCS-CONTENT-CACHE" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/vcs-content-cache.log" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] [%t] %6p - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="REST.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-rest.log" />
-    <param name="maxBackupIndex" value="1" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p [%15.15t] - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="FREEMARKER.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-freemarker.log" />
-    <param name="maxBackupIndex" value="1" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="NOTIFICATIONS.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-notifications.log" />
-    <param name="maxBackupIndex" value="1" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="AGENTPUSH.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-agentPush.log" />
-    <param name="maxBackupIndex" value="1" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="DIAG.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-diagnostics.log" />
-    <param name="maxBackupIndex" value="1" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="NUGET.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-nuget.log" />
-    <param name="maxBackupIndex" value="1" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="ROLL.VERSIONED_SETTINGS" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-versioned-settings.log" />
-    <param name="maxBackupIndex" value="3" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="FLAKY_TESTS.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-flaky-tests.log" />
-    <param name="maxBackupIndex" value="3" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="ISSUE_TRACKERS.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-issue-trackers.log" />
-    <param name="maxBackupIndex" value="3" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <appender name="DISK_USAGE.LOG" class="jetbrains.buildServer.util.TCRollingFileAppender">
-    <param name="file" value="${teamcity_logs}/teamcity-diskusage.log" />
-    <param name="maxBackupIndex" value="3" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%d] %6p - %30.30c - %m%n" />
-    </layout>
-  </appender>
-  <!-- categories -->
-  <category name="jetbrains.buildServer.nuget" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="NUGET.LOG" />
-    <appender-ref ref="CONSOLE-ERROR" />
-    <appender-ref ref="ROLL" />
-  </category>
-  <category name="jetbrains.buildServer.agentpush" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="AGENTPUSH.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.AUTH" additivity="false">
-    <priority value="DEBUG" />
-    <appender-ref ref="ROLL" />
-    <appender-ref ref="AUTH.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.buildTriggers.vcs.clearcase" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="CLEARCASE.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.buildTriggers.vcs.starteam" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="STARTEAM.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.buildTriggers.vcs.tfs" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="TFS.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.XMLRPC" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="XMLRPC.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.AGENTSSTATISTICS" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="AGENT_STATISTICS.LOG" />
-  </category>
-  <category name="javasvn.output" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="SVN.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.SQL" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="SQL.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.CLEANUP" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="ROLL" />
-    <appender-ref ref="CLEANUP.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.LDAP" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="LDAP.LOG" />
-    <appender-ref ref="CONSOLE-ERROR" />
-  </category>
-  <category name="jetbrains.buildServer.vcs.impl.VcsContentCache" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="VCS-CONTENT-CACHE" />
-  </category>
-  <category name="jetbrains.buildServer.server.rest" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="REST.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.clouds.jetbrains.buildServer.serverSide.impl.FlushQueueVirtualAction" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="CLOUDS.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.clouds" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="CLOUDS.LOG" />
-    <appender-ref ref="CONSOLE-ERROR" />
-  </category>
-  <category name="jetbrains.buildServer.ACTIVITIES">
-    <priority value="INFO" />
-    <appender-ref ref="ACTIVITIES.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.VCS" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="ROLL.VCS" />
-    <appender-ref ref="CONSOLE-ERROR" />
-  </category>
-  <category name="jetbrains.buildServer.buildTriggers.vcs" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="ROLL.VCS" />
-    <appender-ref ref="CONSOLE-ERROR" />
-  </category>
-  <category name="jetbrains.buildServer.VCS_STATES" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="ROLL.VCS_STATES" />
-  </category>
-  <category name="jetbrains.buildServer.buildTriggers.vcs.remoteRun" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="ROLL.VCS.REMOTE.RUN" />
-    <appender-ref ref="CONSOLE-ERROR" />
-  </category>
-  <category name="jetbrains.buildServer.notification" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="NOTIFICATIONS.LOG" />
-    <appender-ref ref="CONSOLE-ERROR" />
-  </category>
-  <category name="freemarker.runtime" additivity="false">
-    <priority value="OFF" />
-    <appender-ref ref="FREEMARKER.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.WEBSOCKET" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="ROLL.WS" />
-  </category>
-  <category name="net.sf.packtag.implementation.yui.JavaScriptErrorReporter">
-    <priority value="OFF" />
-  </category>
-  <category name="jetbrains.buildServer.diagnostic" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="DIAG.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.VERSIONED_SETTINGS" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="ROLL.VERSIONED_SETTINGS" />
-  </category>
-  <category name="jetbrains.buildServer.serverSide.impl.versionedSettings" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="ROLL.VERSIONED_SETTINGS" />
-  </category>
-  <category name="jetbrains.buildServer.serverSide.flakyTestDetector" additivity="false">
-    <priority value="WARN" />
-    <appender-ref ref="FLAKY_TESTS.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.ISSUE_TRACKERS" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="ISSUE_TRACKERS.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.serverSide.statistics.diskusage" additivity="false">
-    <priority value="ERROR" />
-    <appender-ref ref="DISK_USAGE.LOG" />
-  </category>
-  <category name="jetbrains.buildServer.SERVER.nodesCommunication" additivity="false">
-    <priority value="INFO" />
-    <appender-ref ref="ROLL.NODES" />
-  </category>
-  <category name="jetbrains.buildServer">
-    <!-- Set this to DEBUG to enable debug logging -->
-    <priority value="INFO" />
-    <appender-ref ref="ROLL" />
-  </category>
-  <category name="org.springframework">
-    <priority value="WARN" />
-    <appender-ref ref="ROLL" />
-  </category>
-  <category name="org.apache.maven.cli.logging">
-    <priority value="ERROR" />
-  </category>
-  <category name="com.onelogin.saml2">
-	<priority value="DEBUG"/>
-	<appender-ref ref="AUTH.LOG"/>
-  </category>
-  <root>
-    <priority value="INFO" />
-    <appender-ref ref="CONSOLE-WARN" />
-  </root>
-</log4j:configuration>
+<Configuration status="INFO">
+  <Appenders>
+    <DelegateAppender>
+      <Console name="CONSOLE-WARN" target="SYSTEM_ERR">
+        <PatternLayout pattern="[%d] %6p [%30.30t] - %30.30c - %m%n" charset="UTF-8" />
+        <SpringErrorsFilter minLevel="WARN" />
+      </Console>
+    </DelegateAppender>
+    <DelegateAppender>
+      <Console name="CONSOLE-ERROR" target="SYSTEM_ERR">
+        <PatternLayout pattern="[%d] %6p [%30.30t] - %30.30c - %m%n" charset="UTF-8" />
+        <SpringErrorsFilter minLevel="ERROR" />
+      </Console>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="ROLL" fileName="${sys:teamcity_logs}/teamcity-server.log" filePattern="${sys:teamcity_logs}/teamcity-server.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="10" fileIndex="min" />
+        <!--REPLACE PREVIOUS LINE WITH UNCOMMENTED LINE TO STORE MORE LOGS-->
+        <!-- <DefaultRolloverStrategy max="20" fileIndex="min"/> -->
+        <Filters>
+          <CategoryFilter denyCategory="javasvn.output" />
+          <CategoryFilter maxDenyLevel="INFO" denyCategory="jetbrains.buildServer.plugins.spring.SpringPluginLoader$TeamCityPlugin*" />
+          <CategoryFilter maxDenyLevel="INFO" denyCategory="jetbrains.buildServer.vcs.impl.VcsContentCache" />
+          <CategoryFilter maxDenyLevel="DEBUG" denyCategory="jetbrains.buildServer.LDAP" />
+          <CategoryFilter maxDenyLevel="INFO" denyCategory="jetbrains.buildServer.maintenance.WebDispatcherServlet" />
+          <CategoryFilter maxDenyLevel="DEBUG" denyCategory="jetbrains.buildServer.CLEANUP" />
+          <CategoryFilter maxDenyLevel="INFO" denyCategory="jetbrains.buildServer.AUTH*" />
+          <CategoryFilter maxDenyLevel="INFO" denyCategory="jetbrains.buildServer.nuget.*" />
+          <CategoryFilter maxDenyLevel="DEBUG" denyCategory="jetbrains.buildServer.web.ResponseFragmentFilter*" />
+        </Filters>
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="ROLL.NODES" fileName="${sys:teamcity_logs}/teamcity-nodes.log" filePattern="${sys:teamcity_logs}/teamcity-nodes.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m %n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="3" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="ROLL.VCS" fileName="${sys:teamcity_logs}/teamcity-vcs.log" filePattern="${sys:teamcity_logs}/teamcity-vcs.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p [%15.15t] - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="3" fileIndex="min" />
+        <!--REPLACE PREVIOUS LINE WITH UNCOMMENTED LINE TO STORE MORE LOGS-->
+        <!-- <DefaultRolloverStrategy max="20" fileIndex="min"/> -->
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="ROLL.VCS_STATES" fileName="${sys:teamcity_logs}/teamcity-vcs-states.log" filePattern="${sys:teamcity_logs}/teamcity-vcs-states.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p [%15.15t] - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="3" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="ROLL.VCS.REMOTE.RUN" fileName="${sys:teamcity_logs}/teamcity-remote-run.log" filePattern="${sys:teamcity_logs}/teamcity-remote-run.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p [%15.15t] - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="5" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="ROLL.WS" fileName="${sys:teamcity_logs}/teamcity-ws.log" filePattern="${sys:teamcity_logs}/teamcity-ws.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p [%15.15t] - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="3" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="ACTIVITIES.LOG" fileName="${sys:teamcity_logs}/teamcity-activities.log" filePattern="${sys:teamcity_logs}/teamcity-activities.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="1" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="CLOUDS.LOG" fileName="${sys:teamcity_logs}/teamcity-clouds.log" filePattern="${sys:teamcity_logs}/teamcity-clouds.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p [%15.15t] - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="10" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="SQL.LOG" fileName="${sys:teamcity_logs}/teamcity-sql.log" filePattern="${sys:teamcity_logs}/teamcity-sql.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30t - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="3" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="CLEANUP.LOG" fileName="${sys:teamcity_logs}/teamcity-cleanup.log" filePattern="${sys:teamcity_logs}/teamcity-cleanup.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="3" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="SVN.LOG" fileName="${sys:teamcity_logs}/teamcity-svn.log" filePattern="${sys:teamcity_logs}/teamcity-svn.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="10" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="TFS.LOG" fileName="${sys:teamcity_logs}/teamcity-tfs.log" filePattern="${sys:teamcity_logs}/teamcity-tfs.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="1" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="STARTEAM.LOG" fileName="${sys:teamcity_logs}/teamcity-starteam.log" filePattern="${sys:teamcity_logs}/teamcity-starteam.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p [%t] - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="1" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="CLEARCASE.LOG" fileName="${sys:teamcity_logs}/teamcity-clearcase.log" filePattern="${sys:teamcity_logs}/teamcity-clearcase.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p [%t] - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="1" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="AUTH.LOG" fileName="${sys:teamcity_logs}/teamcity-auth.log" filePattern="${sys:teamcity_logs}/teamcity-auth.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p [%30.30t] - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="10" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="AGENT_STATISTICS.LOG" fileName="${sys:teamcity_logs}/teamcity-agent-statistics.log" filePattern="${sys:teamcity_logs}/teamcity-agent-statistics.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="%m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="1" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="XMLRPC.LOG" fileName="${sys:teamcity_logs}/teamcity-xmlrpc.log" filePattern="${sys:teamcity_logs}/teamcity-xmlrpc.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="1" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="LDAP.LOG" fileName="${sys:teamcity_logs}/teamcity-ldap.log" filePattern="${sys:teamcity_logs}/teamcity-ldap.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="1" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="VCS-CONTENT-CACHE" fileName="${sys:teamcity_logs}/vcs-content-cache.log" filePattern="${sys:teamcity_logs}/vcs-content-cache.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] [%t] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="3" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="REST.LOG" fileName="${sys:teamcity_logs}/teamcity-rest.log" filePattern="${sys:teamcity_logs}/teamcity-rest.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p [%15.15t] - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="1" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="FREEMARKER.LOG" fileName="${sys:teamcity_logs}/teamcity-freemarker.log" filePattern="${sys:teamcity_logs}/teamcity-freemarker.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="1" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="NOTIFICATIONS.LOG" fileName="${sys:teamcity_logs}/teamcity-notifications.log" filePattern="${sys:teamcity_logs}/teamcity-notifications.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="1" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="AGENTPUSH.LOG" fileName="${sys:teamcity_logs}/teamcity-agentPush.log" filePattern="${sys:teamcity_logs}/teamcity-agentPush.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="1" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="DIAG.LOG" fileName="${sys:teamcity_logs}/teamcity-diagnostics.log" filePattern="${sys:teamcity_logs}/teamcity-diagnostics.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="1" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="NUGET.LOG" fileName="${sys:teamcity_logs}/teamcity-nuget.log" filePattern="${sys:teamcity_logs}/teamcity-nuget.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="1" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="ROLL.VERSIONED_SETTINGS" fileName="${sys:teamcity_logs}/teamcity-versioned-settings.log" filePattern="${sys:teamcity_logs}/teamcity-versioned-settings.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="3" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="FLAKY_TESTS.LOG" fileName="${sys:teamcity_logs}/teamcity-flaky-tests.log" filePattern="${sys:teamcity_logs}/teamcity-flaky-tests.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="3" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="ISSUE_TRACKERS.LOG" fileName="${sys:teamcity_logs}/teamcity-issue-trackers.log" filePattern="${sys:teamcity_logs}/teamcity-issue-trackers.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="3" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="COMMIT_STATUS.LOG" fileName="${sys:teamcity_logs}/teamcity-commit-status.log" filePattern="${sys:teamcity_logs}/teamcity-commit-status.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="3" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="DISK_USAGE.LOG" fileName="${sys:teamcity_logs}/teamcity-diskusage.log" filePattern="${sys:teamcity_logs}/teamcity-diskusage.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="3" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="SEARCH.LOG" fileName="${sys:teamcity_logs}/teamcity-search.log" filePattern="${sys:teamcity_logs}/teamcity-search.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p [%30.30t] - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="3" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="ARTIFACTS.LOG" fileName="${sys:teamcity_logs}/teamcity-artifacts.log" filePattern="${sys:teamcity_logs}/teamcity-artifacts.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="3" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+    <DelegateAppender>
+      <RollingFile name="TRIGGERS.LOG" fileName="${sys:teamcity_logs}/teamcity-triggers.log" filePattern="${sys:teamcity_logs}/teamcity-triggers.log.%i" append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8" />
+        <SizeBasedTriggeringPolicy size="10 MB" />
+        <DefaultRolloverStrategy max="3" fileIndex="min" />
+      </RollingFile>
+    </DelegateAppender>
+  </Appenders>
+  <!-- loggers -->
+  <Loggers>
+    <Logger name="jetbrains.buildServer.nuget" level="INFO" additivity="false">
+      <AppenderRef ref="NUGET.LOG" />
+      <AppenderRef ref="CONSOLE-ERROR" />
+      <AppenderRef ref="ROLL" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.agentpush" level="INFO" additivity="false">
+      <AppenderRef ref="AGENTPUSH.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.AUTH" level="DEBUG" additivity="false">
+      <AppenderRef ref="ROLL" />
+      <AppenderRef ref="AUTH.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.buildTriggers.vcs.clearcase" level="INFO" additivity="false">
+      <AppenderRef ref="CLEARCASE.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.buildTriggers.vcs.starteam" level="INFO" additivity="false">
+      <AppenderRef ref="STARTEAM.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.buildTriggers.vcs.tfs" level="INFO" additivity="false">
+      <AppenderRef ref="TFS.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.XMLRPC" level="INFO" additivity="false">
+      <AppenderRef ref="XMLRPC.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.AGENTSSTATISTICS" level="INFO" additivity="false">
+      <AppenderRef ref="AGENT_STATISTICS.LOG" />
+    </Logger>
+    <Logger name="javasvn.output" level="INFO" additivity="false">
+      <AppenderRef ref="SVN.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.SQL" level="INFO" additivity="false">
+      <AppenderRef ref="SQL.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.CLEANUP" level="INFO" additivity="false">
+      <AppenderRef ref="ROLL" />
+      <AppenderRef ref="CLEANUP.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.LDAP" level="INFO" additivity="false">
+      <AppenderRef ref="LDAP.LOG" />
+      <AppenderRef ref="CONSOLE-ERROR" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.vcs.impl.VcsContentCache" level="INFO" additivity="false">
+      <AppenderRef ref="VCS-CONTENT-CACHE" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.server.rest" level="INFO" additivity="false">
+      <AppenderRef ref="REST.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.server.graphql" level="INFO" additivity="false">
+      <AppenderRef ref="REST.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.clouds.jetbrains.buildServer.serverSide.impl.FlushQueueVirtualAction" level="INFO" additivity="false">
+      <AppenderRef ref="CLOUDS.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.clouds" level="INFO" additivity="false">
+      <AppenderRef ref="CLOUDS.LOG" />
+      <AppenderRef ref="CONSOLE-ERROR" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.ACTIVITIES" level="INFO">
+      <AppenderRef ref="ACTIVITIES.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.VCS" level="INFO" additivity="false">
+      <AppenderRef ref="ROLL.VCS" />
+      <AppenderRef ref="CONSOLE-ERROR" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.buildTriggers.vcs" level="INFO" additivity="false">
+      <AppenderRef ref="ROLL.VCS" />
+      <AppenderRef ref="CONSOLE-ERROR" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.VCS_STATES" level="INFO" additivity="false">
+      <AppenderRef ref="ROLL.VCS_STATES" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.buildTriggers.vcs.remoteRun" level="INFO" additivity="false">
+      <AppenderRef ref="ROLL.VCS.REMOTE.RUN" />
+      <AppenderRef ref="CONSOLE-ERROR" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.notification" level="INFO" additivity="false">
+      <AppenderRef ref="NOTIFICATIONS.LOG" />
+      <AppenderRef ref="CONSOLE-ERROR" />
+    </Logger>
+    <Logger name="freemarker.runtime" level="OFF" additivity="false">
+      <AppenderRef ref="FREEMARKER.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.WEBSOCKET" level="INFO" additivity="false">
+      <AppenderRef ref="ROLL.WS" />
+    </Logger>
+    <Logger name="net.sf.packtag.implementation.yui.JavaScriptErrorReporter" level="OFF" />
+    <Logger name="jetbrains.buildServer.diagnostic" level="INFO" additivity="false">
+      <AppenderRef ref="DIAG.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.VERSIONED_SETTINGS" level="INFO" additivity="false">
+      <AppenderRef ref="ROLL.VERSIONED_SETTINGS" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.serverSide.impl.versionedSettings" level="INFO" additivity="false">
+      <AppenderRef ref="ROLL.VERSIONED_SETTINGS" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.serverSide.flakyTestDetector" level="WARN" additivity="false">
+      <AppenderRef ref="FLAKY_TESTS.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.ISSUE_TRACKERS" level="INFO" additivity="false">
+      <AppenderRef ref="ISSUE_TRACKERS.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.COMMIT_STATUS" level="INFO" additivity="false">
+      <AppenderRef ref="COMMIT_STATUS.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.serverSide.statistics.diskusage" level="ERROR" additivity="false">
+      <AppenderRef ref="DISK_USAGE.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.SERVER.nodesCommunication" level="INFO" additivity="false">
+      <AppenderRef ref="ROLL.NODES" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.serverSide.search" level="WARN" additivity="false">
+      <AppenderRef ref="SEARCH.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.serverSide.build.index" level="WARN" additivity="false">
+      <AppenderRef ref="SEARCH.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.ARTIFACTS" level="ERROR" additivity="false">
+      <AppenderRef ref="ARTIFACTS.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.util.amazon" level="ERROR" additivity="false">
+      <AppenderRef ref="ARTIFACTS.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.artifacts" level="ERROR" additivity="false">
+      <AppenderRef ref="ARTIFACTS.LOG" />
+    </Logger>
+    <Logger name="jetbrains.buildServer.TRIGGERS" level="INFO" additivity="false">
+      <AppenderRef ref="TRIGGERS.LOG" />
+    </Logger>
+    <Logger name="com.jetbrains.teamcity" level="WARN">
+      <!-- new UI overview plugin -->
+      <AppenderRef ref="ROLL" />
+    </Logger>
+    <Logger name="jetbrains.buildServer" level="INFO">
+      <!-- Set level above to DEBUG to enable debug logging -->
+      <AppenderRef ref="ROLL" />
+    </Logger>
+    <Logger name="org.springframework" level="WARN">
+      <AppenderRef ref="ROLL" />
+    </Logger>
+    <Logger name="org.springframework.web.servlet.PageNotFound" level="ERROR" additivity="false">
+      <AppenderRef ref="ROLL" />
+    </Logger>
+    <Logger name="com.onelogin.saml2" level="DEBUG">
+      <AppenderRef ref="AUTH.LOG" />
+    </Logger>
+    <Logger name="org.apache.maven.cli.logging" level="ERROR" />
+    <Root level="INFO">
+      <appender-ref ref="CONSOLE-WARN" />
+    </Root>
+  </Loggers>
+</Configuration>
 


### PR DESCRIPTION
Newer Teamcity Server uses log4j version 2.
Thus, Teamcity can't read older debug log file.

This PR changes log file configuration format to log4j 2 format.