### PR TITLE
Use SimpleEvaluationContext instead of StandardEvaluationContext

### DIFF
--- a/saml-authentication-server/src/main/java/jetbrains/buildServer/auth/saml/plugin/utils/SpelExpressionContext.java
+++ b/saml-authentication-server/src/main/java/jetbrains/buildServer/auth/saml/plugin/utils/SpelExpressionContext.java
@@ -3,17 +3,17 @@ package jetbrains.buildServer.auth.saml.plugin.utils;
 import com.onelogin.saml2.Auth;
 import lombok.var;
 import org.springframework.context.expression.MapAccessor;
-import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.support.SimpleEvaluationContext;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-public class SpelExpressionContext extends StandardEvaluationContext {
+public class SpelExpressionContext {
+    private final EvaluationContext evaluationContext;
 
     public SpelExpressionContext(Map<String, ?> attributes) {
-        setRootObject(attributes);
-        addPropertyAccessor(new MapAccessor());
+        evaluationContext = new SimpleEvaluationContext.Builder(new MapAccessor()).withInstanceMethods().withRootObject(attributes).build();
     }
 
     public SpelExpressionContext(Auth auth) {
@@ -31,11 +31,14 @@ public class SpelExpressionContext extends StandardEvaluationContext {
         attributes.put("nameid", auth.getNameId());
         attributes.put("lastassertionid", auth.getLastAssertionId());
 
-        setRootObject(attributes);
-        addPropertyAccessor(new MapAccessor());
+        evaluationContext = new SimpleEvaluationContext.Builder(new MapAccessor()).withRootObject(attributes).build();
     }
 
     public <T> Map<String, T> getRootObjectAsMap() {
-        return (Map<String, T>) getRootObject().getValue();
+        return (Map<String, T>) evaluationContext.getRootObject().getValue();
+    }
+
+    public EvaluationContext getEvaluationContext() {
+        return evaluationContext;
     }
 }

--- a/saml-authentication-server/src/main/java/jetbrains/buildServer/auth/saml/plugin/utils/SpelExpressionExecutor.java
+++ b/saml-authentication-server/src/main/java/jetbrains/buildServer/auth/saml/plugin/utils/SpelExpressionExecutor.java
@@ -1,16 +1,9 @@
 package jetbrains.buildServer.auth.saml.plugin.utils;
 
-import com.onelogin.saml2.Auth;
 import lombok.extern.slf4j.Slf4j;
 import lombok.var;
-import org.springframework.context.expression.MapAccessor;
-import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.ParseException;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
-import org.springframework.expression.spel.support.StandardEvaluationContext;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @Slf4j
 public class SpelExpressionExecutor {
@@ -29,7 +22,7 @@ public class SpelExpressionExecutor {
     public String evaluate(String expressionString, SpelExpressionContext context) {
         log.debug(String.format("Evaluating expression: %s", expressionString));
         var expression = parser.parseExpression(expressionString);
-        String result = (String) expression.getValue(context);
+        String result = (String) expression.getValue(context.getEvaluationContext());
         log.debug(String.format("Evaluation result: %s", result));
         return result;
     }


### PR DESCRIPTION
StandardEvaluationContext allows arbitrary code, including Runtime class which in its turn can lead to an RCE. Eg https://codethreat.medium.com/reminiscences-of-another-el-injection-62a3335cd22. 

It looks like SimpleEvaluationContext can be safely used instead. 